### PR TITLE
Bump hono version specifier to "^4.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@neondatabase/serverless": "^0.9.3",
     "drizzle-orm": "^0.31.2",
-    "hono": "^4.4.0"
+    "hono": "^4.5.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240403.0",


### PR DESCRIPTION
Not strictly necessary, since 4.5.0 would be installed anyhow given the version specifier in package.json, but it's nice to show we want the latest Hono :) 